### PR TITLE
fix: improve download progress logging

### DIFF
--- a/scripts/download_civitai.py
+++ b/scripts/download_civitai.py
@@ -122,19 +122,26 @@ class CivitAIDownloader:
                 
                 total_size = expected_size or int(response.headers.get('content-length', 0))
                 downloaded_size = 0
-                
+                last_logged = 0
+                log_interval = 100 * 1024 * 1024  # 100MB
+
                 async with aiofiles.open(temp_path, 'wb') as file:
                     async for chunk in response.content.iter_chunked(8192):
                         await file.write(chunk)
                         downloaded_size += len(chunk)
-                        
-                        # Log progress every 100MB
-                        if downloaded_size % (100 * 1024 * 1024) == 0:
+
+                        # Log progress roughly every 100MB downloaded
+                        if downloaded_size - last_logged >= log_interval:
                             if total_size > 0:
                                 progress = (downloaded_size / total_size) * 100
-                                logger.info(f"Progress {filename}: {progress:.1f}% ({downloaded_size / 1024 / 1024:.1f}MB)")
+                                logger.info(
+                                    f"Progress {filename}: {progress:.1f}% ({downloaded_size / 1024 / 1024:.1f}MB)"
+                                )
                             else:
-                                logger.info(f"Downloaded {filename}: {downloaded_size / 1024 / 1024:.1f}MB")
+                                logger.info(
+                                    f"Downloaded {filename}: {downloaded_size / 1024 / 1024:.1f}MB"
+                                )
+                            last_logged = downloaded_size
                 
                 logger.info(f"Download complete: {filename} ({downloaded_size / 1024 / 1024:.1f}MB)")
                 return True


### PR DESCRIPTION
## Summary
- log CivitAI download progress in 100MB increments using threshold tracking

## Testing
- `python -m py_compile scripts/download_civitai.py`
- `python -m py_compile scripts/file_utils.py scripts/download_huggingface.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7013960c0832b925eaa2f5e251edb