### PR TITLE
Refactor download scripts to use package imports

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,2 @@
+"""Utility scripts for model downloads."""
+

--- a/scripts/download_civitai.py
+++ b/scripts/download_civitai.py
@@ -4,7 +4,6 @@ CivitAI model downloader with parallel processing.
 Supports models, LoRAs, and VAEs specified by version IDs.
 """
 
-import os
 import sys
 import asyncio
 import aiohttp
@@ -15,9 +14,7 @@ from typing import List, Dict, Optional, Tuple
 from urllib.parse import urlparse
 import json
 
-# Add the scripts directory to path for imports
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-from file_utils import file_handler
+from .file_utils import file_handler
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/scripts/download_huggingface.py
+++ b/scripts/download_huggingface.py
@@ -4,7 +4,6 @@ HuggingFace model downloader for Flux and other models.
 Supports downloading from HuggingFace repositories with parallel processing.
 """
 
-import os
 import sys
 import asyncio
 import logging
@@ -15,9 +14,7 @@ from huggingface_hub.utils import RepositoryNotFoundError, RevisionNotFoundError
 import concurrent.futures
 import threading
 
-# Add the scripts directory to path for imports
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-from file_utils import file_handler
+from .file_utils import file_handler
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
## Summary
- make `scripts` a Python package for relative imports
- update `download_civitai.py` and `download_huggingface.py` to import `file_handler` via package
- remove `sys.path.append` from downloader scripts

## Testing
- `pytest`
- `python -m scripts.download_civitai --help`
- `python -m scripts.download_huggingface --help`


------
https://chatgpt.com/codex/tasks/task_e_68a704aab41c832baac85490717a5820