### PR TITLE
chore: remove unused imports

### DIFF
--- a/scripts/download_civitai.py
+++ b/scripts/download_civitai.py
@@ -11,8 +11,6 @@ import aiofiles
 import logging
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple
-from urllib.parse import urlparse
-import json
 
 from .file_utils import file_handler
 

--- a/scripts/download_huggingface.py
+++ b/scripts/download_huggingface.py
@@ -12,7 +12,6 @@ from typing import List, Dict, Optional, Tuple
 from huggingface_hub import hf_hub_download, list_repo_files, repo_info
 from huggingface_hub.utils import RepositoryNotFoundError, RevisionNotFoundError
 import concurrent.futures
-import threading
 
 from .file_utils import file_handler
 

--- a/scripts/file_utils.py
+++ b/scripts/file_utils.py
@@ -10,7 +10,7 @@ import tempfile
 import hashlib
 import logging
 from pathlib import Path
-from typing import Optional, Dict
+from typing import Optional
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
## Summary
- remove unused imports from downloader scripts
- clean up file utilities typing imports

## Testing
- `flake8 --select=F401`


------
https://chatgpt.com/codex/tasks/task_e_68a705d00434832b868d522929172700